### PR TITLE
DI-SMOKE-001: Smoke task for Pirlo deployment.

### DIFF
--- a/PIRLO_SMOKE.md
+++ b/PIRLO_SMOKE.md
@@ -1,0 +1,9 @@
+# Pirlo smoke test
+
+This file is a smoke test for the Pirlo agent deployment on the server.
+
+It exists only to prove the end-to-end agent flow works: worktree checkout on the
+`agent/DI-SMOKE-001` branch, file change, verification, and commit. No application
+code is touched, and nothing here is used by `di_core` at runtime.
+
+Safe to delete once the deployment has been verified.


### PR DESCRIPTION
## Что сделано

Smoke task done, with one step blocked.

**What I did:**
1. Created `PIRLO_SMOKE.md` in the repo root — a short note that it's a Pirlo smoke test for the server deployment, stating it touches no application code and is safe to delete.
2. No application code changed (`git diff --stat` on tracked files: empty).
3. Verification: `git status --short` before and after — clean tree beforehand, only the new file afterwards.

**What I couldn't do:** the commit was denied by the permission layer (`git commit` requires approval, and this session is non-interactive). I didn't retry it. The file is **staged** (`A  PIRLO_SMOKE.md`) and HEAD is still `06c6f32b`, so the runner can commit it, or you can approve the command:

```
git commit -m "Add PIRLO_SMOKE.md smoke-test note"
```

Also worth knowing: the `claude.ai` and `Google Drive` MCP servers in this session need authorization before their tools work — claude.ai connectors via your claude.ai connector settings, others via `claude mcp` or `/mcp` in an interactive session. Not needed for this task, just unavailable.

## Прогон

- задача: `DI-SMOKE-001`
- ветка: `agent/DI-SMOKE-001` → `master`
- run-лог на сервере: `DI-SMOKE-001-1785569953.log`
- регламент агента передан в спеке: в репо свой файл-регламент, мы его не перезаписываем

---
Создано агентом pirlo. Мерж — только вручную.
