### PR TITLE
SUP-4-UP: Нужен нейтральный хук после сохранения модели в diCore\Controller\Feedback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.5.2
+
+### `Controller\Feedback::afterModelSaved()` – hook between the save and the email
+
+`sendAction()` used to go straight from `$this->getModel()->save()` to
+`sendEmailNotification()`, so a project extending the controller had no point at
+which to touch the row it had just stored. It now calls `afterModelSaved()` in
+between; the return value is ignored.
+
+The default implementation is empty (`return $this;`), so nothing changes for
+existing projects. The order is the point: an override can create a neighbouring
+record and link the feedback row to it, and the notification then goes out about
+the already-linked message. If `save()` throws, the hook is not called at all.
+
+The signature – no parameters, no declared return type – is part of the contract:
+an override declares it the same way, and adding a return type in the parent
+later would make every existing override incompatible (fatal error on class
+load). The model is reached through `$this->getModel()`.
+
 ## 0.5.1
 
 ### `LocalizationMigration::insertValues()` — keyed by language, not positional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ an override declares it the same way, and adding a return type in the parent
 later would make every existing override incompatible (fatal error on class
 load). The model is reached through `$this->getModel()`.
 
+What the hook does **not** get is a transaction around the row. `save()` opens
+and commits its own (`\diModel::save()`), and the hook runs after that commit
+while still inside `sendAction()`'s `try`. An exception from an override
+therefore only changes the answer — `ok=false`/400, or, for a `SpamException`,
+`ok=true` with the email skipped — and leaves the feedback row stored. The
+client normally resends, which stores it a second time, so an override that can
+fail owns its own cleanup or idempotency.
+
 ## 0.5.1
 
 ### `LocalizationMigration::insertValues()` — keyed by language, not positional

--- a/php/src/diCore/Controller/Feedback.php
+++ b/php/src/diCore/Controller/Feedback.php
@@ -39,6 +39,8 @@ class Feedback extends \diBaseController
 
             $this->getModel()->save();
 
+            $this->afterModelSaved();
+
             if ($ar['ok'] && $this->sendEmail) {
                 $this->sendEmailNotification();
             }
@@ -86,6 +88,18 @@ class Feedback extends \diBaseController
             $this->getModel()->setUserId(\diCore\Tool\Auth::i()->getUserId());
         }
 
+        return $this;
+    }
+
+    /**
+     * Hook called right after the feedback model has been saved
+     * and before the email notification is sent.
+     * Override in your project to attach related data to the fresh row,
+     * model is available via $this->getModel().
+     * Signature must stay as is: no params, no return type.
+     */
+    protected function afterModelSaved()
+    {
         return $this;
     }
 

--- a/php/src/diCore/Controller/Feedback.php
+++ b/php/src/diCore/Controller/Feedback.php
@@ -97,6 +97,13 @@ class Feedback extends \diBaseController
      * Override in your project to attach related data to the fresh row,
      * model is available via $this->getModel().
      * Signature must stay as is: no params, no return type.
+     *
+     * The row is already committed when this runs: \diModel::save() opens and
+     * commits its own transaction, and this call is outside it. So an exception
+     * thrown here does NOT undo the saved feedback row - it only turns the
+     * response into an error (and a SpamException even keeps ok=true, just
+     * skipping the email). The client will usually resend and store a duplicate,
+     * so an override is responsible for its own cleanup or idempotency.
      */
     protected function afterModelSaved()
     {


### PR DESCRIPTION
## Что сделано

Готово.

**Что сделано:**

- `php/src/diCore/Controller/Feedback.php:94` – добавлен пустой хук `afterModelSaved()`: без параметров, без объявленного типа возврата, тело `return $this;`. В докблоке зафиксировано, что сигнатуру менять нельзя и что модель берётся через `$this->getModel()`.
- `php/src/diCore/Controller/Feedback.php:42` – вызов `$this->afterModelSaved()` в `sendAction()` сразу после `$this->getModel()->save()` и до блока `if ($ar['ok'] && $this->sendEmail)`. Возвращаемое значение игнорируется; вызов внутри того же `try`, поэтому при исключении из `save()` хук не выполняется.
- `CHANGELOG.md` – секция 0.5.2 (0.5.1 уже протегирован) с описанием хука и причины требований к сигнатуре.

**Проверка:** `php -l` на изменённом файле – ошибок нет. Тестов на `Controller\Feedback` в `php/tests/` нет, новых не добавлял: хук по умолчанию пустой, поведение существующих проектов не меняется.

Потребитель на стороне 1romantic (`Romantic\Controller\Feedback::afterModelSaved`) заработает после мержа и обновления `composer.lock` в проекте.

## Само-ревью

- класс diff: `medium`, категории: correctness
- ревьюеры: codex, claude
- раундов: 1 из 2
- сошлось: блокеров не осталось, замечания ниже важностью исправлены
- полный разбор ревью: `/var/log/pirlo/di_core/SUP-4-UP-review.md` (на сервере, ротируется вместе с run-логами)

### Подтверждено и исправлено (1)

- `php/src/diCore/Controller/Feedback.php:42` — Исключение из переопределённого afterModelSaved() перехватывается общими catch'ами sendAction() уже ПОСЛЕ коммита строки обратной связи: клиент получает ok=false/400 при сохранённой записи (повтор отправки продублирует строку), а SpamException из хука вообще проглатывается с ok=true и молча отменяет… (claude, correctness) — Взял первый вариант из suggest — задокументировал. В PHPDoc afterModelSaved() добавлено, что строка уже закоммичена (save() ведёт собственную транзакцию, вызов вне неё), исключение из хука не откатывает запись, а лишь меняет ответ (SpamException — оставляет ok=true и пропускает письмо), и что наслед…

## Прогон

- задача: `SUP-4-UP`
- ветка: `agent/SUP-4-UP` → `master`
- run-лог на сервере: `SUP-4-UP-1788050780.log`
- регламент агента передан в спеке: в репо свой файл-регламент, мы его не перезаписываем

---
Создано агентом pirlo. Мерж — только вручную.
